### PR TITLE
Early2014release

### DIFF
--- a/scripts/Pychrm_Build_Classifier.py
+++ b/scripts/Pychrm_Build_Classifier.py
@@ -115,12 +115,6 @@ def addToFeatureSet(ftb, ds, fts, classId, imagesOnly):
             message += '\tProcessing features for image id:%d\n' % imId
 
             sig = pychrm.FeatureSet.Signatures()
-            # Versioning exists to account for the years of legacy features
-            # that were calculated using buggy algorithms
-            # Anything calculated after this point in time is major version 2
-            # Minor version .0 refers to the fact that the features being loaded
-            # aren't necessarily part of a recognized set of features
-            sig.version = '2.0'
             (sig.names, sig.values) = ftb.loadFeatures(imId)
             sig.source_file = str(imId)
             fts.AddSignature(sig, classId)

--- a/scripts/Pychrm_Build_Classifier.py
+++ b/scripts/Pychrm_Build_Classifier.py
@@ -115,6 +115,12 @@ def addToFeatureSet(ftb, ds, fts, classId, imagesOnly):
             message += '\tProcessing features for image id:%d\n' % imId
 
             sig = pychrm.FeatureSet.Signatures()
+            # Versioning exists to account for the years of legacy features
+            # that were calculated using buggy algorithms
+            # Anything calculated after this point in time is major version 2
+            # Minor version .0 refers to the fact that the features being loaded
+            # aren't necessarily part of a recognized set of features
+            sig.version = '2.0'
             (sig.names, sig.values) = ftb.loadFeatures(imId)
             sig.source_file = str(imId)
             fts.AddSignature(sig, classId)

--- a/scripts/Pychrm_Feature_Extraction_Multichannel.py
+++ b/scripts/Pychrm_Feature_Extraction_Multichannel.py
@@ -30,8 +30,10 @@ from itertools import izip
 from tempfile import NamedTemporaryFile
 
 
-from OmeroPychrm import PychrmStorage
+import pychrm
 from pychrm.FeatureSet import Signatures
+from pychrm.PyImageMatrix import PyImageMatrix
+from OmeroPychrm import PychrmStorage
 
 try:
     from PIL import Image, ImageDraw, ImageFont     # see ticket:2597
@@ -40,23 +42,6 @@ except: #pragma: nocover
         import Image, ImageDraw, ImageFont          # see ticket:2597
     except:
         raise omero.ServerError('No PIL installed')
-
-
-
-def getTifs(im):
-    sz = (im.getSizeX(), im.getSizeY())
-    nch = im.getSizeC()
-    zctlist = [(0, ch, 0) for ch in xrange(im.getSizeC())]
-    planes = im.getPrimaryPixels().getPlanes(zctlist)
-    tifs = [Image.fromarray(p) for p in planes]
-
-    tmpfs = []
-    for tif in tifs:
-        with NamedTemporaryFile(suffix='.tif', delete=False) as tmpf:
-            tif.save(tmpf.name)
-        tmpfs.append(tmpf)
-
-    return tmpfs
 
 
 def extractFeatures(ftb, ds, newOnly, chNames, imageId = None, im = None,
@@ -86,19 +71,26 @@ def extractFeatures(ftb, ds, newOnly, chNames, imageId = None, im = None,
         if newOnly and ftb.tableContainsId(imageId):
             return message + 'Image id:%d features already in table' % imageId
 
-    # Pychrm only takes tifs
-    tmpfs = getTifs(im)
+    # FIXME: default is convert multichannel to greyscale unless user input
 
     # Calculate features for an image channel
-    # Override the temporary filename
     # Optionally prepend the channel label to each feature name and combine
     ftall = None
-    for tmpf, ch in izip(tmpfs, chNames):
-        ft = Signatures.SmallFeatureSet(tmpf.name)
+    for c in xrange( len( chNames ) ):
+	    
+        pychrm_matrix = PyImageMatrix()
+        pychrm_matrix.allocate( im.getSizeX(), im.getSizeY() )
+        numpy_matrix = pychrm_matrix.as_ndarray()
+
+        numpy_matrix[:] = im.getPrimaryPixels().getPlane(theZ=0,theC=c,theT=0)
+        feature_plan = pychrm.StdFeatureComputationPlans.getFeatureSet();
+        options = "" # This is where you can tell wnd-charm to normalize pixel intensities, 
+                     # take ROIs etc. ... leave blank for now.
+        ft = Signatures.NewFromFeatureComputationPlan( pychrm_matrix, feature_plan, options )  
+
         if prefixChannel:
             ft.names = ['[%s] %s' % (ch, n) for n in ft.names]
         ft.source_path = im.getName()
-        tmpf.unlink(tmpf.name)
         if not ftall:
             ftall = ft
         else:

--- a/scripts/Pychrm_Feature_Extraction_Multichannel.py
+++ b/scripts/Pychrm_Feature_Extraction_Multichannel.py
@@ -89,7 +89,7 @@ def extractFeatures(ftb, ds, newOnly, chNames, imageId = None, im = None,
         ft = Signatures.NewFromFeatureComputationPlan( pychrm_matrix, feature_plan, options )  
 
         if prefixChannel:
-            ft.names = ['[%s] %s' % (ch, n) for n in ft.names]
+            ft.names = ['[%s] %s' % (c, n) for n in ft.names]
         ft.source_path = im.getName()
         if not ftall:
             ftall = ft

--- a/scripts/Pychrm_Predict.py
+++ b/scripts/Pychrm_Predict.py
@@ -161,15 +161,7 @@ def addToFeatureSet(ftb, ds, fts, classId):
         imId = image.getId()
         message += '\tProcessing features for image id:%d\n' % imId
         #message += extractFeatures(tc, d, im = image) + '\n'
-
         sig = pychrm.FeatureSet.Signatures()
-        # Versioning exists to account for the years of legacy features
-        # that were calculated using buggy algorithms
-        # Anything calculated after this point in time is major version 2
-        # Minor version .0 refers to the fact that the features being loaded
-        # aren't necessarily part of a recognized set of features
-        sig.version = '2.0'
-
         (sig.names, sig.values) = ftb.loadFeatures(imId)
         #sig.source_file = image.getName()
         sig.source_file = str(imId)

--- a/scripts/Pychrm_Predict.py
+++ b/scripts/Pychrm_Predict.py
@@ -163,6 +163,13 @@ def addToFeatureSet(ftb, ds, fts, classId):
         #message += extractFeatures(tc, d, im = image) + '\n'
 
         sig = pychrm.FeatureSet.Signatures()
+        # Versioning exists to account for the years of legacy features
+        # that were calculated using buggy algorithms
+        # Anything calculated after this point in time is major version 2
+        # Minor version .0 refers to the fact that the features being loaded
+        # aren't necessarily part of a recognized set of features
+        sig.version = '2.0'
+
         (sig.names, sig.values) = ftb.loadFeatures(imId)
         #sig.source_file = image.getName()
         sig.source_file = str(imId)
@@ -236,9 +243,8 @@ def runScript():
     """
 
     client = scripts.client(
-        'Pychrm_Build_Classifier.py',
-        'Build a classifier from features calculated over two or more ' +
-        'datasets, each dataset represents a different class',
+        'Pychrm_Predict.py',
+        'Tag images based on their classification result',
 
         scripts.String('Data_Type', optional=False, grouping='1',
                        description='The source data to be predicted.',


### PR DESCRIPTION
Load pixels directly into Pychrm from OMERO rather than writing a temporary tiff.

Also deals with some Pychrm object versioning (separate issue from feature versioning)
