### PR TITLE
Cross validation script

### DIFF
--- a/scripts/Pychrm_Cross_Validation.py
+++ b/scripts/Pychrm_Cross_Validation.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2013 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#
+#
+from omero import scripts
+import omero.model
+from omero.rtypes import rstring, rlong, unwrap
+from datetime import datetime
+from math import ceil
+from itertools import izip
+from StringIO import StringIO
+
+from OmeroPychrm import PychrmStorage
+
+from pychrm.FeatureSet import DiscreteClassificationExperimentResult, \
+    DiscreteBatchClassificationResult, FeatureSet_Discrete, \
+    FisherFeatureWeights, Signatures
+
+def crossValidate(ftb, project, featureThreshold, imagesOnly, numSplits):
+
+    message = ''
+    fullSet = FeatureSet_Discrete()
+    fullSet.source_path = project.getName()
+
+    classId = 0
+    for ds in project.listChildren():
+        message += 'Processing dataset id:%d\n' % ds.getId()
+        message += addToFeatureSet(ftb, ds, fullSet, classId, imagesOnly)
+        classId += 1
+
+    tmp = fullSet.ContiguousDataMatrix()
+    experiment = DiscreteClassificationExperimentResult(training_set=fullSet)
+
+    for i in range(numSplits):
+        trainSet, testSet = fullSet.Split()
+        trainSet.Normalize()
+        testSet.Normalize(trainSet)
+
+        weights = FisherFeatureWeights.NewFromFeatureSet(trainSet)
+
+        nFeatures = ceil(len(weights.names) * featureThreshold)
+        message += 'Selecting top %d features\n' % nFeatures
+        weights = weights.Threshold(nFeatures)
+        trainSet = reduceFeatures(trainSet, weights)
+
+        reducedTestSet = reduceFeatures(testSet, weights)
+        reducedTrainSet = reduceFeatures(trainSet, weights)
+
+	batchResult = DiscreteBatchClassificationResult.New(
+            reducedTrainSet, reducedTestSet, weights, batch_number=i)
+	experiment.individual_results.append(batchResult)
+
+    out = StringIO()
+    experiment.Print(output_stream=out)
+    try:
+        experiment.PredictedValueAnalysis(output_stream=out)
+    except Exception as e:
+        m = 'Error in experiment.PredictedValueAnalysis: %s' % e
+        message += m + '\n'
+        out.write('\n' + m + '\n')
+
+    pid = project.getId()
+    PychrmStorage.addTextFileAnnotationTo(
+        ftb.conn, out.getvalue(), 'Project', pid,
+        'Pychrm_Cross_Validation_Results.txt',
+        'Pychrm Cross Validation Results for Project:%d' % pid)
+
+    message += 'Attached cross-validation results\n'
+    #return experiment
+    return message
+
+
+def reduceFeatures(fts, weights):
+    if fts.source_path is None:
+        fts.source_path = ''
+    ftsr = fts.FeatureReduce(weights.names)
+    return ftsr
+
+
+def addToFeatureSet(ftb, ds, fts, classId, imagesOnly):
+    message = ''
+
+    tid = PychrmStorage.getAttachedTableFile(ftb.tc, ds)
+    if tid:
+        if not ftb.openTable(tid):
+            return message + '\nERROR: Table not opened'
+        version = unwrap(ftb.versiontag.getTextValue())
+        message += 'Opened table id:%d version:%s\n' % (tid, version)
+    else:
+        message += 'ERROR: Table not found for Dataset id:%d' % ds.getId()
+        return message
+
+    if imagesOnly:
+        for image in ds.listChildren():
+            imId = image.getId()
+            message += '\tProcessing features for image id:%d\n' % imId
+
+            sig = Signatures()
+            (sig.names, sig.values) = ftb.loadFeatures(imId)
+            sig.source_file = str(imId)
+            sig.version = version
+            fts.AddSignature(sig, classId)
+
+    else:
+        names, values, ids = ftb.bulkLoadFeatures()
+        message += '\tProcessing all features for dataset id:%d\n' % ds.getId()
+
+        for imId, vals in izip(ids, values):
+            sig = Signatures()
+            sig.names = names
+            sig.values = vals
+            sig.source_file = str(imId)
+            sig.version = version
+            fts.AddSignature(sig, classId)
+
+    fts.classnames_list[classId] = ds.getName()
+    return message
+
+
+def runCrossValidate(client, scriptParams):
+    message = ''
+
+    # for params with default values, we can get the value directly
+    dataType = scriptParams['Data_Type']
+    projectId = scriptParams['IDs']
+    contextName = scriptParams['Context_Name']
+    featureThreshold = scriptParams['Features_threshold'] / 100.0
+    numSplits = scriptParams['Number_of_splits']
+    imagesOnly = scriptParams['Cross_Reference_Table_Images']
+
+    if len(projectId) != 1:
+        raise Exception('A single project must be provided')
+
+    projectId = projectId[0]
+
+    tableNameIn = '/Pychrm/' + contextName + PychrmStorage.SMALLFEATURES_TABLE
+    message += 'tableNameIn:' + tableNameIn + '\n'
+
+    ftb = PychrmStorage.FeatureTable(client, tableNameIn)
+
+    try:
+        message += 'Running cross-validation\n'
+        trainProject = ftb.conn.getObject(dataType, projectId)
+        msg = crossValidate(
+            ftb, trainProject, featureThreshold, imagesOnly, numSplits)
+        message += msg
+
+    except:
+        print message
+        raise
+    finally:
+        ftb.close()
+
+    return message
+
+
+def runScript():
+    """
+    The main entry point of the script, as called by the client via the scripting service, passing the required parameters. 
+    """
+
+    client = scripts.client(
+        'Pychrm_Cross_Validation.py',
+        'Run multiple cross-validation iterations',
+
+        scripts.String('Data_Type', optional=False, grouping='1',
+                       description='The training source.',
+                       values=[rstring('Project')], default='Project'),
+
+        scripts.List(
+            'IDs', optional=False, grouping='1',
+            description='Project ID').ofType(rlong(0)),
+
+        scripts.String(
+            'Context_Name', optional=False, grouping='1',
+            description='The name of the classification context.',
+            default='Example'),
+
+        scripts.Long(
+            'Features_threshold', optional=False, grouping='2',
+            description='The proportion of features to keep (%)\n' + \
+                '(Should be a Double but doesn\'t seem to work)',
+            default=15),
+
+        scripts.Long(
+            'Number_of_splits', optional=False, grouping='2',
+            description='The number of cross-validation splits',
+            default=5),
+
+        scripts.Bool(
+            'Cross_Reference_Table_Images', optional=False, grouping='2',
+            description='Should the features table be cross-references with the list of images in the dataset?',
+            default=True),
+
+        version = '0.0.1',
+        authors = ['Simon Li', 'Chris Coletta', 'OME Team'],
+        institutions = ['University of Dundee'],
+        contact = 'ome-users@lists.openmicroscopy.org.uk',
+    )
+
+    try:
+        startTime = datetime.now()
+        session = client.getSession()
+        client.enableKeepAlive(60)
+        scriptParams = {}
+
+        # process the list of args above.
+        for key in client.getInputKeys():
+            if client.getInput(key):
+                scriptParams[key] = client.getInput(key, unwrap=True)
+        message = str(scriptParams) + '\n'
+
+        # Run the script
+        message += runCrossValidate(client, scriptParams) + '\n'
+
+        stopTime = datetime.now()
+        message += 'Duration: %s' % str(stopTime - startTime)
+
+        print message
+        client.setOutput('Message', rstring(str(message)))
+
+    finally:
+        client.closeSession()
+
+if __name__ == '__main__':
+    runScript()
+

--- a/scripts/Pychrm_Cross_Validation.py
+++ b/scripts/Pychrm_Cross_Validation.py
@@ -71,12 +71,7 @@ def crossValidate(ftb, project, featureThreshold, imagesOnly, numSplits):
 
     out = StringIO()
     experiment.Print(output_stream=out)
-    try:
-        experiment.PredictedValueAnalysis(output_stream=out)
-    except Exception as e:
-        m = 'Error in experiment.PredictedValueAnalysis: %s' % e
-        message += m + '\n'
-        out.write('\n' + m + '\n')
+    experiment.PerSampleStatistics(output_stream=out)
 
     pid = project.getId()
     PychrmStorage.addTextFileAnnotationTo(

--- a/tests/test_PychrmStorage.py
+++ b/tests/test_PychrmStorage.py
@@ -555,6 +555,27 @@ class TestAnnotations(ClientHelper):
 
         self.delete('/Project', pid)
 
+    def test_addTextFileAnnotationTo(self):
+        pid = self.create_project('addTextFileAnnotationTo')
+        txt = 'This is\nsome text.'
+        filename = 'addTextFileAnnotationTo.txt'
+        description = 'Description of addTextFileAnnotationTo.txt'
+        PychrmStorage.addTextFileAnnotationTo(
+            self.conn, txt, 'Project', pid, filename, description)
+
+        p = self.conn.getObject('Project', pid)
+        anns = list(p.listAnnotations())
+        self.assertEqual(len(anns), 1)
+        a = anns[0]
+
+        self.assertEqual(a.getFileName(), filename)
+        self.assertEqual(a.getDescription(), description)
+        self.assertEqual(a.getFileSize(), len(txt))
+        self.assertEqual(list(a.getFileInChunks())[0], txt)
+
+        self.delete('/Annotation', a.getId())
+        self.delete('/Project', pid)
+
     def test_addTagTo(self):
         pid = self.create_project('addTagTo')
         txt = 'This is a tag'


### PR DESCRIPTION
Adds a cross-validation script, based on https://github.com/wnd-charm/wnd-charm/blob/master/examples/classifier_cross_validation.py, see #18.

Requires wnd-charm/wnd-charm#26

Note the cross validation script is curently broken:

```
In [17]: e.PredictedValueAnalysis()
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-17-8ed307c64bfa> in <module>()
----> 1 e.PredictedValueAnalysis()

/Users/simon/omero-test/venv/lib/python2.7/site-packages/pychrm-0.2-py2.7-macosx-10.8-x86_64.egg/pychrm/FeatureSet.pyc in print_method_wrapper(*args, **kwargs)
    201                                 sys.stdout = backup
    202                 else:
--> 203                         retval = method_that_prints_output( *args, **kwargs )
    204                 return retval
    205

/Users/simon/omero-test/venv/lib/python2.7/site-packages/pychrm-0.2-py2.7-macosx-10.8-x86_64.egg/pychrm/FeatureSet.pyc in PredictedValueAnalysis(self)
   4062                         vals = np.array( [result.predicted_value for result in self.accumulated_individual_results[filename] ])
   4063                         self.ground_truth_values.append( self.accumulated_individual_results[filename][0].ground_truth_value )
-> 4064                         self.predicted_values.append( np.mean(vals) )
   4065                         self.individual_stats[filename] = ( len(vals), np.min(vals), np.mean(vals), \
   4066                                                             np.max(vals), np.std(vals) )

/usr/local/lib/python2.7/site-packages/numpy/core/fromnumeric.pyc in mean(a, axis, dtype, out, keepdims)
   2486
   2487     return _methods._mean(a, axis=axis, dtype=dtype,
-> 2488                             out=out, keepdims=keepdims)
   2489
   2490

/usr/local/lib/python2.7/site-packages/numpy/core/_methods.pyc in _mean(a, axis, dtype, out, keepdims)
     55                         out=ret, casting='unsafe', subok=False)
     56     else:
---> 57         ret = ret / float(rcount)
     58     return ret
     59

TypeError: unsupported operand type(s) for /: 'NoneType' and 'float'
```
