### PR TITLE
trainFts.imagenames_list must contain strings

### DIFF
--- a/scripts/Pychrm_Predict.py
+++ b/scripts/Pychrm_Predict.py
@@ -79,7 +79,7 @@ def loadClassifier(ctb, project):
     trainFts.num_classes = nclasses
 
     trainFts.featurenames_list = cls['featureNames']
-    trainFts.imagenames_list = cls['ids']
+    trainFts.imagenames_list = [str(i) for i in cls['ids']]
     tmp = trainFts.ContiguousDataMatrix()
 
     weights = pychrm.FeatureSet.FisherFeatureWeights(


### PR DESCRIPTION
Fix predict script to work with changes in https://github.com/wnd-charm/wnd-charm/pull/31
