### PR TITLE
Feature channel names

### DIFF
--- a/OmeroPychrm/PychrmStorage.py
+++ b/OmeroPychrm/PychrmStorage.py
@@ -82,6 +82,16 @@ def createFeatureName(ft, idx):
     return name
 
 
+def insert_channel_name(ftname, cname):
+    """
+    Inserts a channel name into a raw feature name
+    """
+    if ftname.find('()') < 0:
+        raise PychrmStorageError(
+            'Expected \'()\' in raw feature name: %s' % ftname)
+    return ftname.replace('()', '(%s)' % cname)
+
+
 def featureSizes(names):
     """
     Convert a list of single value feature names to a dictionary of

--- a/scripts/Pychrm_Feature_Extraction_Multichannel.py
+++ b/scripts/Pychrm_Feature_Extraction_Multichannel.py
@@ -44,8 +44,7 @@ except: #pragma: nocover
         raise omero.ServerError('No PIL installed')
 
 
-def extractFeatures(ftb, ds, newOnly, chNames, imageId = None, im = None,
-                    prefixChannel = True):
+def extractFeatures(ftb, ds, newOnly, chNames, imageId = None, im = None):
     message = ''
     tc = ftb.tc
 
@@ -90,8 +89,7 @@ def extractFeatures(ftb, ds, newOnly, chNames, imageId = None, im = None,
                      # take ROIs etc. ... leave blank for now.
         ft = Signatures.NewFromFeatureComputationPlan( pychrm_matrix, feature_plan, options )  
 
-        if prefixChannel:
-            ft.names = ['[%s] %s' % (c, n) for n in ft.names]
+        ft.names = ['[%s] %s' % (c, n) for n in ft.names]
         ft.source_path = im.getName()
         if not ftall:
             ftall = ft
@@ -146,7 +144,6 @@ def processImages(client, scriptParams):
     ids = scriptParams['IDs']
     contextName = scriptParams['Context_Name']
     newOnly = scriptParams['New_Images_Only']
-    prefixChannel = scriptParams['Prefix_Channel']
 
     tableName = '/Pychrm/' + contextName + '/SmallFeatureSet.h5'
     message += 'tableName:' + tableName + '\n'
@@ -172,15 +169,11 @@ def processImages(client, scriptParams):
                 'Channel check failed, ' +
                 'all images must have the same channels: %s' % message)
 
-        if not prefixChannel and len(chNames) != 1:
-            raise omero.ServerError(
-                'Multiple channels found, Prefix_Channel must be True')
         for d in datasets:
             message += 'Processing dataset id:%d\n' % d.getId()
             for image in d.listChildren():
                 message += 'Processing image id:%d\n' % image.getId()
-                msg = extractFeatures(ftb, d, newOnly, chNames, im=image,
-                                      prefixChannel=prefixChannel)
+                msg = extractFeatures(ftb, d, newOnly, chNames, im=image)
                 message += msg + '\n'
 
     except:
@@ -218,11 +211,6 @@ def runScript():
         scripts.Bool(
             'New_Images_Only', optional=False, grouping='3',
             description='If features already exist for an image do not recalculate.',
-            default=True),
-
-        scripts.Bool(
-            'Prefix_Channel', optional=False, grouping='4',
-            description='Prefix feature names with the channel name, must be true for multichannel images.',
             default=True),
 
         version = '0.0.1',

--- a/scripts/Pychrm_Feature_Extraction_Multichannel.py
+++ b/scripts/Pychrm_Feature_Extraction_Multichannel.py
@@ -89,7 +89,8 @@ def extractFeatures(ftb, ds, newOnly, chNames, imageId = None, im = None):
                      # take ROIs etc. ... leave blank for now.
         ft = Signatures.NewFromFeatureComputationPlan( pychrm_matrix, feature_plan, options )  
 
-        ft.names = ['[%s] %s' % (c, n) for n in ft.names]
+        ft.names = [PychrmStorage.insert_channel_name(
+                    n, chNames[c]) for n in ft.names]
         ft.source_path = im.getName()
         if not ftall:
             ftall = ft

--- a/tests/test_PychrmStorage.py
+++ b/tests/test_PychrmStorage.py
@@ -105,6 +105,10 @@ class TestPychrmStorage(unittest.TestCase):
         r = PychrmStorage.createFeatureName('a b', 321)
         self.assertEqual(r, 'a b [321]')
 
+    def insert_channel_name(self):
+        r = PychrmStorage.insert_channel_name('a (b ()) [3]', 'ch')
+        self.assertEqual(r, 'a (b (ch)) [3]')
+
     def featureSizes(self):
         ftsz = PychrmStorage.featureSizes(['a b [12]', 'c d [3]', 'a b [14]'])
         self.assertEqual(len(ftsz.keys), 2)

--- a/tests/test_PychrmStorage.py
+++ b/tests/test_PychrmStorage.py
@@ -101,21 +101,21 @@ class TestPychrmStorage(unittest.TestCase):
         self.assertEqual(r[0], 'a b')
         self.assertEqual(r[1], 321)
 
-    def createFeatureName(self):
+    def test_createFeatureName(self):
         r = PychrmStorage.createFeatureName('a b', 321)
         self.assertEqual(r, 'a b [321]')
 
-    def insert_channel_name(self):
+    def test_insert_channel_name(self):
         r = PychrmStorage.insert_channel_name('a (b ()) [3]', 'ch')
         self.assertEqual(r, 'a (b (ch)) [3]')
 
-    def featureSizes(self):
+    def test_featureSizes(self):
         ftsz = PychrmStorage.featureSizes(['a b [12]', 'c d [3]', 'a b [14]'])
-        self.assertEqual(len(ftsz.keys), 2)
-        self.assertIn(ftsz, 'a b')
-        self.assertIn(ftsz, 'c d')
-        self.assertEqual(ftsz['a b'], 14)
-        self.assertEqual(ftsz['c d'], 3)
+        self.assertEqual(len(ftsz.keys()), 2)
+        self.assertIn('a b', ftsz)
+        self.assertIn('c d', ftsz)
+        self.assertEqual(ftsz['a b'], 15)
+        self.assertEqual(ftsz['c d'], 4)
 
 
 class FeatureTableHelper(ClientHelper):


### PR DESCRIPTION
Store the channel name as part of the feature name, e.g. If the channel name is `channel 0` then store `'Multiscale Histograms (Fourier (channel 0))'`
