### PR TITLE
README changed to use ome/omero-wndcharm repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ must be run twice.
 
 Although OmeroPychrm can be installed using pip:
 
-    pip install git+git://github.com/manics/omero-pychrm.git
+    pip install git+git://github.com/ome/omero-wndcharm.git
 
 The scripts for using WND-CHRM in OMERO are also in the same Github source
 repository so you still need to clone it:
 
-    git clone https://github.com/manics/omero-pychrm.git
-    cd omero-pychrm
+    git clone https://github.com/ome/omero-wndcharm.git
+    cd omero-wndcharm
     python setup.py install
 
 Copy the scripts into the OMERO.server script directory:


### PR DESCRIPTION
Change the README to reflect the pending repo name change to fit with wnd-charm/wnd-charm#35
